### PR TITLE
Update minimum version for scikit-learn.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     install_requires = [
         'Cython>=0.21.1',
         'lxml',
-        'scikit-learn==0.15.2',
+        'scikit-learn>=0.15.2',
         'numpy',
         'scipy',
         'mozsci'


### PR DESCRIPTION
We're using it on a project now with 0.16.1 and it seems fine.