### PR TITLE
Stylistic cleanup and (start of) Py2/3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 *.so
 build/*
+dist/*
 dragnet.egg-info
 
 # cython temporary files
@@ -22,4 +23,3 @@ output/*
 *.swp
 
 .vagrant
-

--- a/dragnet/__init__.py
+++ b/dragnet/__init__.py
@@ -1,14 +1,12 @@
-#! /usr/bin/env python
-
-from .arias import AriasFeatures, Arias
-from .blocks import Blockifier, PartialBlock, BlockifyError
-from .features import NormalizedFeature, CSSFeatures
-from .content_extraction_model import ContentExtractionModel
-from .kohlschuetter import kohlschuetter_features, kohlschuetter
-from .util import evaluation_metrics
-from .weninger import weninger_features_kmeans
-from .readability import readability_features
-from .models import content_extractor, content_comments_extractor
+from dragnet.arias import AriasFeatures, Arias
+from dragnet.blocks import Blockifier, PartialBlock, BlockifyError
+from dragnet.features import NormalizedFeature, CSSFeatures
+from dragnet.content_extraction_model import ContentExtractionModel
+from dragnet.kohlschuetter import kohlschuetter_features, kohlschuetter
+from dragnet.util import evaluation_metrics
+from dragnet.weninger import weninger_features_kmeans
+from dragnet.readability import readability_features
+from dragnet.models import content_extractor, content_comments_extractor
 
 
 class AllFeatures(object):

--- a/dragnet/__init__.py
+++ b/dragnet/__init__.py
@@ -13,7 +13,7 @@ from .models import content_extractor, content_comments_extractor
 
 class AllFeatures(object):
     """Easy access to feature instances.
-    
+
     We need a way to get instances of the feature classes.
     Since these classes are potentially mutated by clients,
     we create a new instance on each access"""
@@ -32,4 +32,3 @@ class AllFeatures(object):
             return NormalizedFeature(readability_features)
         else:
             raise KeyError
-

--- a/dragnet/arias.py
+++ b/dragnet/arias.py
@@ -1,13 +1,14 @@
 #! /usr/bin/env python
-
-# A /rough/ implementation of that described by Aurias et al.:
-#    https://lirias.kuleuven.be/bitstream/123456789/215528/1/AriasEtAl2009.pdf
-
+"""
+A *rough* implementation of that described by Aurias et al.:
+https://lirias.kuleuven.be/bitstream/123456789/215528/1/AriasEtAl2009.pdf
+"""
 from .blocks import Blockifier
 from .content_extraction_model import ContentExtractionModel, IdentityPredictor
 
 import numpy as np
 import scipy.weave
+
 
 class AriasFeatures(object):
     """A global feature based on connected blocks of long text
@@ -24,7 +25,6 @@ class AriasFeatures(object):
         self._percent_cutoff = percent_cutoff
         self._window = window
 
-
     def __call__(self, blocks, train=False):
         from scipy import percentile
         features = np.zeros((len(blocks), AriasFeatures.nfeatures))
@@ -35,7 +35,6 @@ class AriasFeatures(object):
         lowindex, highindex = AriasFeatures.strip(block_lengths, index, self._window, cutoff)
         features[lowindex:(highindex + 1), 0] = 1.0
         return features
-
 
     @staticmethod
     def strip(block_lengths, index, window, cutoff):
@@ -83,9 +82,10 @@ class AriasFeatures(object):
             }
             ret(1) = lastindex;
         """
-        scipy.weave.inline(c_code,
-                ['ret', 'nblock', 'index', 'window', 'cutoff', 'block_lengths'],
-                type_converters=scipy.weave.converters.blitz)
+        scipy.weave.inline(
+            c_code,
+            ['ret', 'nblock', 'index', 'window', 'cutoff', 'block_lengths'],
+            type_converters=scipy.weave.converters.blitz)
         return ret
 
 
@@ -108,18 +108,19 @@ class Arias(ContentExtractionModel):
         import matplotlib.pyplot as plt
 
         # First, plot up to the low point in blue...
-        p1 = plt.bar(np.arange(low), [len(l) for l in L[0:low]], linewidth=0.0)
+        plt.bar(np.arange(low), [len(l) for l in L[0:low]], linewidth=0.0)
         # And now from low-high in red
-        p2 = plt.bar(np.arange(low, hi+1), [len(l) for l in L[low:hi+1]],
+        plt.bar(
+            np.arange(low, hi + 1), [len(l) for l in L[low:hi + 1]],
             linewidth=0.0, color='r')
         # And from then on in blue
-        p3 = plt.bar(np.arange(hi+1, len(L)), [len(l) for l in L[hi+1:]],
+        plt.bar(
+            np.arange(hi + 1, len(L)), [len(l) for l in L[hi + 1:]],
             linewidth=0.0)
         # Lastly, apply a line across the board at the cutoff
-        line = plt.plot([0, len(L)], [cutoff, cutoff], 'g-')
+        plt.plot([0, len(L)], [cutoff, cutoff], 'g-')
 
         plt.xlabel('Order')
         plt.ylabel('Length')
         plt.title(name)
         plt.show()
-

--- a/dragnet/blocks.pyx
+++ b/dragnet/blocks.pyx
@@ -51,23 +51,21 @@ cdef inline int int_min(int a, int b): return a if a <= b else b
 
 # tags we'll ignore completely
 cdef cpp_set[string] BLACKLIST
-BLACKLIST = set([
-    'applet', 'area', 'base', 'basefont', 'bdo', 'button', 
-    'caption', 'fieldset', 'fram', 'frameset', 
-    'iframe', 'img', 'input', 'legend', 'link', 'menu', 'meta', 
-    'noframes', 'noscript', 'object', 'optgroup', 'option', 'param', 
-    'script', 'select', 'style', 'textarea', 'var', 'xmp',
-    'like', 'like-box', 'plusone',
+BLACKLIST = {
+    b'applet', b'area', b'base', b'basefont', b'bdo', b'button',
+    b'caption', b'fieldset', b'fram', b'frameset',
+    b'iframe', b'img', b'input', b'legend', b'link', b'menu', b'meta',
+    b'noframes', b'noscript', b'object', b'optgroup', b'option', b'param',
+    b'script', b'select', b'style', b'textarea', b'var', b'xmp',
+    b'like', b'like-box', b'plusone',
     # HTML5 vector image tags and math tags
-    'svg', 'math'
-])
+    b'svg', b'math'
+    }
 
 
 # tags defining the blocks we'll extract
 cdef cpp_set[string] BLOCKS
-BLOCKS = set([
-    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div', 'table', 'map',
-])
+BLOCKS = {b'h1', b'h2', b'h3', b'h4', b'h5', b'h6', b'p', b'div', b'table', b'map'}
 
 # define some commonly used strings here, otherwise Cython will always add
 # a little python overhead when using them even though they are constat
@@ -87,14 +85,13 @@ re_readability_positive = re.compile('article|body|content|entry|hentry|main|pag
 cdef string DIV = <string>'div'
 
 cdef cpp_set[string] READABILITY_PLUS3
-READABILITY_PLUS3 = set(["pre", "td", "blockquote"])
+READABILITY_PLUS3 = {b'pre', b'td', b'blockquote'}
 
 cdef cpp_set[string] READABILITY_MINUS3
-READABILITY_MINUS3 = set(
-    ["address", "ol", "ul", "dl", "dd", "dt", "li", "form"])
+READABILITY_MINUS3 = {b'address', b'ol', b'ul', b'dl', b'dd', b'dt', b'li', b'form'}
 
 cdef cpp_set[string] READABILITY_MINUS5
-READABILITY_MINUS5 = set(["h1", "h2", "h3", "h4", "h5", "h6", "th"])
+READABILITY_MINUS5 = {b'h1', b'h2', b'h3', b'h4', b'h5', b'h6', b'th'}
 
 
 cdef cpp_set[char] WHITESPACE = set([<char>' ', <char>'\t', <char>'\n',
@@ -571,7 +568,7 @@ cdef class PartialBlock:
         # finally store it
         self.class_weights.push_back(pair[uint32_t, int](self.tag_id, weight))
         self.class_weights_written.insert(self.tag_id)
-    
+
     cdef void reinit_readability(self):
         self.ancestors_write = self.ancestors
 
@@ -695,12 +692,12 @@ cdef class TagCountPB(PartialBlock):
     # Since we don't output empty blocks, we also keep track of the
     # tag count since the last block we output as an additional feature
     #
-    
+
     # _tc = tag count in the current block, since the last <div>, <p>, etc.
     # _tc_lb = tag count since last block.  This is the tag count in prior
     # empty blocks, accumulated since the last block was output, excluding
     # the current block
-    
+
     # so tc gets updated with each tag
     # tc is reset on block formation, even for empty blocks
     #
@@ -776,7 +773,7 @@ xml_re = re.compile('<\?\s*xml[^>]*encoding\s*=\s*"{0,1}\s*([a-zA-Z0-9-]+)', re.
 def guess_encoding(s, default='utf-8'):
     """Try to guess the encoding of s -- check the XML declaration
     and the HTML meta tag
-    
+
     if default=CHARDET then use chardet to guess the default"""
     mo = xml_re.search(s)
     if mo:
@@ -820,7 +817,7 @@ class Blockifier(object):
         partial_block.add_block_to_results(results)
 
         return results
-    
+
 
     @staticmethod
     def blockify(s, encoding=None,
@@ -878,5 +875,3 @@ class TagCountNoCSSReadabilityBlockifier(Blockifier):
         return Blockifier.blockify(s, encoding, pb=TagCountPB,
             do_css=False, do_readability=True,
             parse_callback=parse_callback)
-
-

--- a/dragnet/compat.py
+++ b/dragnet/compat.py
@@ -1,0 +1,14 @@
+import sys
+
+PY2 = int(sys.version[0]) == 2
+
+if PY2:
+    range_ = xrange
+    bytes_ = str
+    unicode_ = unicode
+    string_ = (str, unicode)
+else:
+    range_ = range
+    bytes_ = bytes
+    unicode_ = str
+    string_ = (bytes, str)

--- a/dragnet/content_extraction_model.py
+++ b/dragnet/content_extraction_model.py
@@ -1,9 +1,8 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-
-import re
 import numpy as np
 from .blocks import Blockifier
+
 
 class IdentityPredictor(object):
     """Mock out the machine learning model with an identity model."""
@@ -15,6 +14,7 @@ class IdentityPredictor(object):
     def fit(*args, **kargs):
         pass
 
+
 class BaselinePredictor(object):
     """Always predict content"""
     @staticmethod
@@ -25,16 +25,19 @@ class BaselinePredictor(object):
     def fit(*args, **kwargs):
         pass
 
+
 def nofeatures(blocks, *args, **kwargs):
     return np.zeros((len(blocks), 1))
+
 nofeatures.nfeatures = 1
+
 
 class ContentExtractionModel(object):
     """Content extraction model
 
     Encapsulates a blockifier, some feature generators and a
     machine learing block model
-    
+
     Implements analyze, make_features"""
 
     def __init__(self, blockifier, features, block_model, threshold=0.5):
@@ -55,7 +58,7 @@ class ContentExtractionModel(object):
 
     def set_threshold(self, thres):
         """Set the threshold
-        
+
         0<= thres <= 1.0"""
         self._threshold = thres
 
@@ -68,8 +71,8 @@ class ContentExtractionModel(object):
             If None, then try to guess it.
         """
         # blockify html into blocks
-        blocks_ = self._blockifier.blockify(s, encoding=encoding,
-            parse_callback=parse_callback)
+        blocks_ = self._blockifier.blockify(
+            s, encoding=encoding, parse_callback=parse_callback)
 
         # make features, run model and return content
         return self.analyze_from_blocks(blocks_, return_blocks=blocks)
@@ -112,13 +115,13 @@ class ContentExtractionModel(object):
 
            raises BlockifyError if there is an error parsing the doc
            and None if doc is too short (< 3 blocks)
-           
+
            train = if true, then passes it into feature maker
         """
         # note: this method is not longer needed by ContentExtractionModel
         # but is kept for now for backward compatibilty with training code
-        blocks = self._blockifier.blockify(s, encoding=encoding,
-            parse_callback=parse_callback)
+        blocks = self._blockifier.blockify(
+            s, encoding=encoding, parse_callback=parse_callback)
         return self.make_features_from_blocks(blocks, train), blocks
 
     @staticmethod
@@ -133,20 +136,19 @@ class ContentExtractionModel(object):
         block_lengths_no_content = block_lengths.copy()
         block_lengths_no_content[content_mask] = 0.0
 
-        ret = plt.bar(np.arange(len(blocks)), block_lengths_no_content, 0.5)
-        ret = plt.bar(np.arange(len(blocks)), block_lengths_content, 0.5)
+        plt.bar(np.arange(len(blocks)), block_lengths_no_content, 0.5)
+        plt.bar(np.arange(len(blocks)), block_lengths_content, 0.5)
 
         fig.show()
 
 
 class ContentCommentsExtractionModel(ContentExtractionModel):
-    '''
+    """
     Run two models: a content only and a content + comments model
     on a document and return the output of both
-    '''
+    """
     def __init__(self, blockifier, features,
-        content_model, content_comments_model, threshold=0.5):
-
+                 content_model, content_comments_model, threshold=0.5):
         self._blockifier = blockifier
         self._features = features
         self._content_model = content_model
@@ -203,7 +205,8 @@ class ContentCommentsExtractionModel(ContentExtractionModel):
             return (
                 ' '.join(blk.text for blk in blocks_content),
                 ' '.join(blk.text for blk in blocks_content_comments)
-            )
+                )
+
 
 class SklearnWrapper(object):
     def __init__(self, skmodel):
@@ -216,4 +219,3 @@ class SklearnWrapper(object):
         return self._skmodel.predict_proba(X)[:, self._positive_idx]
 
 baseline_model = ContentExtractionModel(Blockifier, [nofeatures], BaselinePredictor)
-

--- a/dragnet/data_processing.py
+++ b/dragnet/data_processing.py
@@ -1,6 +1,6 @@
+from __future__ import print_function
 
 import re
-import json
 import numpy as np
 import glob
 import codecs
@@ -9,14 +9,18 @@ import os
 from .blocks import Blockifier, simple_tokenizer, text_from_subtree
 from lxml import etree
 
+
 def add_plot_title(ti_str):
     """Add a string as a title on top of a subplot"""
     import pylab as plt
     plt.figtext(0.5, 0.94, ti_str, ha='center', color='black', weight='bold', size='large')
 
+
 re_has_text = re.compile("^\s*<text")
 re_open_tag = re.compile('^\s*<text.+encoding\s*=\s*"([a-zA-Z0-9-_\s]+)"\s*>')
 re_end_tag = re.compile('</\s*text\s*>\s*$')
+
+
 def read_HTML_file(datadir, fileroot):
     """Reads the HTML file from the datadir with fileroot.
     This checks for an optional <text> tag specifying the encoding,
@@ -52,6 +56,7 @@ def read_gold_standard(datadir, fileroot, cetr=False):
         (1) assume no comments and (2) parse the gold standard to remove tags"""
 
     corrected_file = datadir + '/Corrected/%s.html.corrected.txt' % fileroot
+
     def read_file(encoding):
         return codecs.open(corrected_file, 'r', encoding=encoding).read()
 
@@ -166,7 +171,6 @@ def extract_gold_standard(datadir, fileroot,
             all_blocks_tokens_block_id.extend([i] * len(block))
         i += 1
 
-
     gold_standard_content_comments = read_gold_standard(datadir, fileroot, cetr)
     content_comments = ['content', 'comments']
 
@@ -181,14 +185,14 @@ def extract_gold_standard(datadir, fileroot,
             gold_standard_tokens = tokenizer(txt.encode('utf-8'))
         else:
             gold_standard_tokens = tokenizer(txt)
-    
-        print "Got all tokens for %s.  %s in all blocks, %s in gold standard %s" % (fileroot, len(all_blocks_tokens), len(gold_standard_tokens), content_comments[k])
+
+        print("Got all tokens for %s.  %s in all blocks, %s in gold standard %s" % (fileroot, len(all_blocks_tokens), len(gold_standard_tokens), content_comments[k]))
         ABT = len(all_blocks_tokens)
         NN += len(gold_standard_tokens)
 
-        tokens_in_gold_standard = check_inclusion(all_blocks_tokens,
-            gold_standard_tokens)
-    
+        tokens_in_gold_standard = check_inclusion(
+            all_blocks_tokens, gold_standard_tokens)
+
         # now make a percentage of tokens in the gold standard for each block
         blocks_token_count = [0] * len(blocks)
         blocks_tokens_in_gold_standard = [0] * len(blocks)
@@ -198,7 +202,7 @@ def extract_gold_standard(datadir, fileroot,
             if block[0]:
                 blocks_tokens_in_gold_standard[block[1]] += 1
                 blocks_tokens_in_gold_standard_tokens[block[1]] += block[2] + ' '
-    
+
         # the array of block level token percent
         token_percent = [-1 if ele[0] == 0 else float(ele[1]) / ele[0] for ele in zip(blocks_token_count, blocks_tokens_in_gold_standard)]
 
@@ -208,11 +212,9 @@ def extract_gold_standard(datadir, fileroot,
     if NN > ABT:
         with open('bad_data.txt', 'a') as fbad:
             fbad.write('\t'.join((fileroot, str(NN), str(ABT), datadir)) + '\n')
-        
 
     # write the final output file
-    with open(datadir + '/block_corrected/%s.block_corrected.txt' % fileroot,
-        'w') as f:
+    with open(datadir + '/block_corrected/%s.block_corrected.txt' % fileroot, 'w') as f:
         for block in zip(content_comments_percent[0], content_comments_percent[1], blocks_tokens, content_comments_tokens[0], content_comments_tokens[1]):
             f.write(str(block[0]) + '\t' + str(block[1]) + '\t')
             if block[2] == '':
@@ -243,7 +245,7 @@ def extract_gold_standard_all_training_data(datadir, nprocesses=1, **kwargs):
     # all the corrected files
     for file, fileroot in get_list_all_corrected_files(datadir):
         if fileroot not in fileroot_already_corrected:
-            print "Extracting gold standard for file %s" % fileroot
+            print("Extracting gold standard for file %s" % fileroot)
             if use_pool:
                 p.apply_async(extract_gold_standard, (datadir, fileroot), kwargs)
             else:
@@ -252,7 +254,6 @@ def extract_gold_standard_all_training_data(datadir, nprocesses=1, **kwargs):
     if use_pool:
         p.close()
         p.join()
-
 
 
 class DragnetModelData(object):
@@ -281,7 +282,7 @@ class DragnetModelData(object):
         elif source == 'all':
             re_keep = ''  # match anything
         else:
-            raise InputError, "Invalid source"
+            raise ValueError("Invalid source")
         self._re_source = re.compile(re_keep)
         self._source = source
 
@@ -292,12 +293,12 @@ class DragnetModelData(object):
         """Return nkeep sample HTML docs from the training data
         Returns [(fileroot1, data), (..), ..]"""
 
-        ordering = zip(np.random.rand(len(self.training_files)),
-                    np.arange(len(self.training_files)))
+        ordering = zip(
+            np.random.rand(len(self.training_files)),
+            np.arange(len(self.training_files)))
         ordering.sort()
         indices_to_keep = [ind for seed, ind in ordering[:nkeep]]
         return [(self.training_files[ind], self.training_data[ind]) for ind in indices_to_keep]
-
 
     def _read_all_data(self, datadir, block_percent_threshold, source):
         """
@@ -329,7 +330,7 @@ class DragnetModelData(object):
                     '%s/block_corrected/%s.block_corrected.txt' %
                     (datadir, fileroot), 'r')
                 blocks = block_corrected_file.read()[:-1].split('\n')
-    
+
                 content = []
                 comments = []
                 for block in blocks:
@@ -337,7 +338,7 @@ class DragnetModelData(object):
                     # will store the weights as the total number of tokens in the document
                     content.append((float(block_split[0]), len(block_split[2].strip().split()), block_split[3].strip().split()))
                     comments.append((float(block_split[1]), len(block_split[2].strip().split()), block_split[4].strip().split()))
-    
+
                 ret = []
                 for content_comments in [content, comments]:
                     extracted_flag = (np.array([ele[0] for ele in content_comments]) > block_percent_threshold).astype(np.int)
@@ -347,7 +348,7 @@ class DragnetModelData(object):
                     for this_block_tokens in [ele[2] for ele in content_comments if ele[1] > 0]:
                         tokens.extend(this_block_tokens)
                     ret.append((extracted_flag, counts, tokens))
-    
+
                 if fileroot in training_fileroot:
                     self.training_data.append((html, ret[0], ret[1], encoding))
                     self.training_files.append(fileroot)
@@ -357,7 +358,6 @@ class DragnetModelData(object):
 
         print("..done!")
         print("Got %s training, %s test documents" % (len(self.training_data), len(self.test_data)))
-
 
     @staticmethod
     def diagnose_css(datadir, plotdir):
@@ -393,7 +393,6 @@ class DragnetModelData(object):
             for tag in ['id', 'class']:
                 popular_tokens_sorted[c][tag] = [(v, k) for k, v in popular_tokens[c][tag].iteritems()]
                 popular_tokens_sorted[c][tag].sort(reverse=True)
-
 
         # write to a file with percent of total
         for c in ['content', 'no_content']:
@@ -440,8 +439,6 @@ class DragnetModelData(object):
                 for t in content_no_content_ratio[tag]:
                     f.write("%s\t%s\t%s\t%s\n" % t)
 
-
-
     @staticmethod
     def diagnose_data(datadir, plotdir, training_or_test='both'):
         """Do some diagnosis if the data set
@@ -452,9 +449,9 @@ class DragnetModelData(object):
         # we will accumulate the percent extracted for some histograms
         percent_extracted = []
         for s, t in [('all', 'All data'),
-                    ('technoratti', 'Technoratti'),
-                    ('domain_list', "Domain list"),
-                    ('reader', "Popular RSS on Google Reader")]:
+                     ('technoratti', 'Technoratti'),
+                     ('domain_list', "Domain list"),
+                     ('reader', "Popular RSS on Google Reader")]:
 
             data = DragnetModelData(datadir, source=s)
             data._diagnose_data_one_source(plotdir, t, training_or_test='both')
@@ -473,7 +470,6 @@ class DragnetModelData(object):
         fig.show()
         fig.savefig(plotdir + '/percent_tokens_extracted.png')
 
-
     def _get_percent_tokens_extracted_in_block(self, datadir):
         ret = []
         for file, fileroot in get_list_all_corrected_files(datadir):
@@ -489,7 +485,6 @@ class DragnetModelData(object):
                     ret.append(float(block_split[0]))
 
         return np.asarray(ret)
-
 
     def _diagnose_data_one_source(self, plotdir, ti, training_or_test='both'):
         """Make some plots and do some exploratory analyis on training data
@@ -508,11 +503,11 @@ class DragnetModelData(object):
             plot_data = self.training_data + self.test_data
             files = self.training_files + self.test_files
         else:
-            raise InputError, "Invalid training_or_test"
+            raise ValueError("Invalid training_or_test")
 
         # block_level_aggreate = holds block count of # extracted as
         #                        content, comments and total
-        block_level_aggregate = {'content':[], 'comments':[], 'total':[]}
+        block_level_aggregate = {'content': [], 'comments': [], 'total': []}
         for datum in plot_data:
             k = 1
             block_level_aggregate['total'].append(len(datum[1][1]))
@@ -542,7 +537,7 @@ class DragnetModelData(object):
         for s in ['content', 'comments']:
             txt += "\nTotal %s %s (%s %%)" % (s, int(np.sum(block_level_aggregate[s])), np.sum(block_level_aggregate[s]) / np.sum(block_level_aggregate['total']) * 100)
         plt.figtext(0.6, 0.4, txt)
-        
+
         add_plot_title(ti + '\nBlock level, training + test')
 
         fig.show()
@@ -550,8 +545,9 @@ class DragnetModelData(object):
 
         # percent extracted as content vs block number
         bins = 20
-        content_percent_vs_block_percent = {'content':np.zeros((len(plot_data), bins)),
-                                            'comments':np.zeros((len(plot_data), bins))}
+        content_percent_vs_block_percent = {
+            'content': np.zeros((len(plot_data), bins)),
+            'comments': np.zeros((len(plot_data), bins))}
 
         # number of tokens in block vs block number
         block_length_vs_block_percent = np.zeros((len(plot_data), bins))
@@ -630,4 +626,3 @@ def split_data(datadir):
     # write training/test lists
     open(datadir + '/training.txt', 'w').write('\n'.join([ele[1] for ele in all_files[:ntrain]]))
     open(datadir + '/test.txt', 'w').write('\n'.join([ele[1] for ele in all_files[ntrain:]]))
-

--- a/dragnet/data_processing.py
+++ b/dragnet/data_processing.py
@@ -7,6 +7,7 @@ import codecs
 import os
 
 from .blocks import Blockifier, simple_tokenizer, text_from_subtree
+from .compat import range_, unicode_
 from lxml import etree
 
 
@@ -179,9 +180,9 @@ def extract_gold_standard(datadir, fileroot,
 
     NN = 0
 
-    for k in xrange(len(gold_standard_content_comments)):
+    for k in range_(len(gold_standard_content_comments)):
         txt = gold_standard_content_comments[k]
-        if type(txt) == unicode:
+        if isinstance(txt, unicode_):
             gold_standard_tokens = tokenizer(txt.encode('utf-8'))
         else:
             gold_standard_tokens = tokenizer(txt)
@@ -371,8 +372,8 @@ class DragnetModelData(object):
             blocks = Blockifier.blockify(datum[0], encoding=datum[3])
             extracted = np.logical_or(datum[1][0], datum[2][0])
             assert len(blocks) == len(extracted)
-            content_css.extend([blocks[k].css for k in xrange(len(blocks)) if extracted[k]])
-            no_content_css.extend([blocks[k].css for k in xrange(len(blocks)) if not extracted[k]])
+            content_css.extend([blocks[k].css for k in range_(len(blocks)) if extracted[k]])
+            no_content_css.extend([blocks[k].css for k in range_(len(blocks)) if not extracted[k]])
 
         # make a list of the most popular tokens
         from collections import defaultdict
@@ -403,11 +404,10 @@ class DragnetModelData(object):
                     cumcount = 0
                     for count, token in popular_tokens_sorted[c][tag]:
                         cumcount += count
-                        f.write("%s\t%s\t%s\t%s\n" %
-                                    (count,
-                                     token,
-                                     float(count)/total_tokens,
-                                     float(cumcount) / total_tokens))
+                        f.write("%s\t%s\t%s\t%s\n" % (count,
+                                                      token,
+                                                      float(count) / total_tokens,
+                                                      float(cumcount) / total_tokens))
 
         # take the ratio of token count in content vs no content
         # for the tokens in the specified list
@@ -552,7 +552,7 @@ class DragnetModelData(object):
         # number of tokens in block vs block number
         block_length_vs_block_percent = np.zeros((len(plot_data), bins))
 
-        for datum_number in xrange(len(plot_data)):
+        for datum_number in range_(len(plot_data)):
             datum = plot_data[datum_number]
             k = 1
             for c in ['content', 'comments']:

--- a/dragnet/features.py
+++ b/dragnet/features.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
-
 import re
 import numpy as np
-import json
 
 # implementations of the features interface.
 #
@@ -15,12 +13,12 @@ import json
 # It has an attribute "feature.nfeatures" that gives number of features
 #
 # To allow the feature to set itself from some data, feature can optionally
-#   implement 
+#   implement
 #       feature.init_parms(computed_features) AND
 #       features.set_params(ret)
 #   where computed_features is a call with train=True,
 #   and ret is the returned value from features.init_params.
-#
+
 
 def normalize_features(features, mean_std):
     """Normalize the features IN PLACE.
@@ -30,7 +28,7 @@ def normalize_features(features, mean_std):
        mean_std = {'mean':[list of means],
                    'std':[list of std] }
        the lists are the same length as features.shape[1]
-       
+
        if features is None, then do nothing"""
     if features is not None:
         for k in xrange(features.shape[1]):
@@ -41,7 +39,7 @@ class NormalizedFeature(object):
     """Normalize a feature with mean/std
 
     This is an abstraction of a normalized feature
-    It acts sort of like a decorator on anything 
+    It acts sort of like a decorator on anything
     that implements the feature interface.
 
     Instances of this object also implement the feature interface"""
@@ -66,8 +64,8 @@ class NormalizedFeature(object):
         return features
 
     def init_params(self, features):
-        self._mean_std = {'mean':features.mean(axis=0),
-                          'std':features.std(axis=0) }
+        self._mean_std = {'mean': features.mean(axis=0),
+                          'std': features.std(axis=0)}
         return self._mean_std
 
     def set_params(self, mean_std):
@@ -147,5 +145,3 @@ class CSSFeatures(object):
                 ret[:, feature] = [re.search(token, block.css[attrib]) is not None for block in blocks]
                 feature += 1
         return ret
-
-

--- a/dragnet/features.py
+++ b/dragnet/features.py
@@ -130,9 +130,12 @@ class CSSFeatures(object):
                                   'thread',
                                   'author',
                                   'tools',
-                                  'reply',
-                                  'url',
-                                  'avatar']  # , 'ss']  <-- duplicate?!
+                                  # these two strings were implicitly concatenated
+                                  # this is a bug, and it will be fixed
+                                  'reply' + 'url',
+                                  'avatar',
+                                  # this is a duplicate entry (see above)
+                                  'ss']
                         }
 
     _attribute_order = ['id', 'class']

--- a/dragnet/features.py
+++ b/dragnet/features.py
@@ -2,6 +2,8 @@
 import re
 import numpy as np
 
+from .compat import range_, string_
+
 # implementations of the features interface.
 #
 # feature is a callable feature(list_of_blocks, train=False)
@@ -31,7 +33,7 @@ def normalize_features(features, mean_std):
 
        if features is None, then do nothing"""
     if features is not None:
-        for k in xrange(features.shape[1]):
+        for k in range_(features.shape[1]):
             features[:, k] = (features[:, k] - mean_std['mean'][k]) / mean_std['std'][k]
 
 
@@ -79,7 +81,7 @@ class NormalizedFeature(object):
         or a json blob.
         if a string, load it, otherwise just return"""
         import json
-        if isinstance(mean_std, basestring):
+        if isinstance(mean_std, string_):
             return json.load(open(mean_std, 'r'))
         else:
             return mean_std
@@ -95,47 +97,47 @@ class CSSFeatures(object):
     # attribute.
     # The features are 0/1 flags whether these tokens
     # appear in the CSS tags
-    attribute_tokens = {'id':['nav',
-                              'ss',
-                              'top',
-                              'content',
-                              'link',
-                              'title',
-                              'comment',
-                              'tools',
-                              'rating',
-                              'ss'],
-                     'class':['menu',
-                              'widget',
-                              'nav',
-                              'share',
-                              'facebook',
-                              'cat',
-                              'top',
-                              'content',
-                              'item',
-                              'twitter',
-                              'button',
-                              'title',
-                              'header',
-                              'ss',
-                              'post',
-                              'comment',
-                              'meta',
-                              'alt',
-                              'time',
-                              'depth',
-                              'thread',
-                              'author',
-                              'tools',
-                              'reply'
-                              'url',
-                              'avatar',
-                              'ss']}
+    attribute_tokens = {'id': ['nav',
+                               'ss',
+                               'top',
+                               'content',
+                               'link',
+                               'title',
+                               'comment',
+                               'tools',
+                               'rating',
+                               'ss'],
+                        'class': ['menu',
+                                  'widget',
+                                  'nav',
+                                  'share',
+                                  'facebook',
+                                  'cat',
+                                  'top',
+                                  'content',
+                                  'item',
+                                  'twitter',
+                                  'button',
+                                  'title',
+                                  'header',
+                                  'ss',
+                                  'post',
+                                  'comment',
+                                  'meta',
+                                  'alt',
+                                  'time',
+                                  'depth',
+                                  'thread',
+                                  'author',
+                                  'tools',
+                                  'reply',
+                                  'url',
+                                  'avatar']  # , 'ss']  <-- duplicate?!
+                        }
 
     _attribute_order = ['id', 'class']
 
-    nfeatures = sum(len(ele) for ele in attribute_tokens.itervalues())
+    nfeatures = sum(len(ele) for ele in attribute_tokens.values())
 
     def __call__(self, blocks, train=False):
         ret = np.zeros((len(blocks), CSSFeatures.nfeatures))

--- a/dragnet/kmeans.py
+++ b/dragnet/kmeans.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from .compat import range_
+
 
 class KMeans(object):
 
@@ -14,12 +16,12 @@ class KMeans(object):
         """Returns the indices of the closest clusters to X
         Return is length(X.shape[0])"""
         distances = np.zeros((X.shape[0], self.clusters))
-        for k in xrange(self.clusters):
+        for k in range_(self.clusters):
             distances[:, k] = np.sum((X - self.centers[k, :]) ** 2, axis=1)
         return distances.argmin(axis=1)
 
     def update_centers(self, X, cc):
-        for k in xrange(self.clusters):
+        for k in range_(self.clusters):
             these_indices = cc == k
             if np.any(these_indices):
                 self.centers[k, :] = np.mean(X[these_indices, :], axis=0)
@@ -35,7 +37,7 @@ class KMeans(object):
         """initialize centers to random values"""
         # randomly assign data in X to a cluster center, then take means
         self.centers = np.zeros((self.clusters, self._nx))
-        for k in xrange(self.clusters):
+        for k in range_(self.clusters):
             self._init_one_center(X, k)
 
     def fit(self, X):
@@ -59,13 +61,14 @@ class KMeans(object):
             last_centers = self.centers.copy()
 
     def plot_clusters(self, X):
+        import matplotlib.pyplot as plt
         assert X.shape[1] == 2
         fig = plt.figure(1)
         fig.clf()
 
         colors = ['b', 'r', 'g']
         indices = self.closest_centers(X)
-        for k in xrange(self.clusters):
+        for k in range_(self.clusters):
             this_cluster = indices == k
             plt.scatter(X[this_cluster, 0], X[this_cluster, 1], s=2, color=colors[k])
             plt.plot(self.centers[k][0], self.centers[k][1], 'kx', markersize=10)

--- a/dragnet/kmeans.py
+++ b/dragnet/kmeans.py
@@ -1,11 +1,11 @@
-
 import numpy as np
+
 
 class KMeans(object):
 
     def __init__(self, clusters):
         self.clusters = clusters
-        self.centers = None # (nclusters X nx)
+        self.centers = None  # (nclusters X nx)
         self._nx = None
         self._errtol = 1e-3
         self._maxiterations = 50
@@ -30,7 +30,7 @@ class KMeans(object):
     def _init_one_center(self, X, k):
         # initialize center k randomly
         self.centers[k, :] = X[np.random.randint(X.shape[0]), :]
-    
+
     def _init_centers(self, X):
         """initialize centers to random values"""
         # randomly assign data in X to a cluster center, then take means
@@ -72,6 +72,7 @@ class KMeans(object):
 
         fig.show()
 
+
 class KMeansFixedOrigin(KMeans):
     """KMeans with once cluster always fixed to origin"""
 
@@ -82,5 +83,3 @@ class KMeansFixedOrigin(KMeans):
     def update_centers(self, X, cc):
         super(KMeansFixedOrigin, self).update_centers(X, cc)
         self.centers[0, :] = np.zeros(self._nx)
-
-

--- a/dragnet/kohlschuetter.py
+++ b/dragnet/kohlschuetter.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from .content_extraction_model import ContentExtractionModel
 from .blocks import Blockifier
+from .compat import range_
 
 
 def kohlschuetter_features(blocks, train=False):
@@ -16,7 +17,7 @@ def kohlschuetter_features(blocks, train=False):
     assert len(blocks) >= 3
 
     features = np.zeros((len(blocks), 6))
-    for i in range(1, len(blocks) - 1):
+    for i in range_(1, len(blocks) - 1):
         previous = blocks[i - 1]
         current = blocks[i]
         next_ = blocks[i + 1]
@@ -73,7 +74,7 @@ class KohlschuetterBlockModel(object):
 
         results = []
 
-        for i in xrange(features.shape[0]):
+        for i in range_(features.shape[0]):
             (previous_link_density, previous_text_density,
              current_link_density, current_text_density,
              next_link_density, next_text_density) = features[i, :]

--- a/dragnet/model_training.py
+++ b/dragnet/model_training.py
@@ -10,6 +10,7 @@ from mozsci.cross_validate import cv_kfold
 
 from .blocks import Blockifier
 from . import evaluation_metrics
+from .compat import range_
 from .content_extraction_model import ContentExtractionModel
 from .data_processing import (simple_tokenizer, DragnetModelData, read_gold_standard,
                               get_list_all_corrected_files, read_HTML_file,
@@ -200,9 +201,9 @@ def plot_errors(errors, reg_parm_str):
     label = ['train', 'test']
     fig = plt.figure(1)
     fig.clf()
-    for k in xrange(2):
+    for k in range_(2):
         varn = 0
-        for varn in xrange(len(vars)):
+        for varn in range_(len(vars)):
             plt.subplot(230 + varn + 1)
             plt.plot(np.log(reg_parm), errors_plot[k, :, varn], label=label[k])
             plt.title(vars[varn])
@@ -271,7 +272,7 @@ def evaluate_models_tokens(datadir, dragnet_model, figname_root=None,
     for froot, gstok in gold_standard_tokens.iteritems():
         html, encoding = read_HTML_file(datadir, froot)
         if use_list:
-            for i in xrange(len(dragnet_model)):
+            for i in range_(len(dragnet_model)):
                 # make an analyze function to handle the encoding
                 dm = lambda x: dragnet_model[i].analyze(x, encoding=encoding)
                 errors[k, :, i] = run_score_content_detection(
@@ -289,7 +290,7 @@ def evaluate_models_tokens(datadir, dragnet_model, figname_root=None,
         fig = plt.figure(1)
         fig.clf()
 
-        for k in xrange(3):
+        for k in range_(3):
             plt.subplot(2, 2, k + 1)
             plt.hist(errors[:, k], 20)
             plt.title("%s %s" % (ti[k], np.mean(errors[:, k])))
@@ -316,7 +317,7 @@ def evaluate_models_tokens(datadir, dragnet_model, figname_root=None,
         avg_scores = scores.mean(axis=0)
         std_scores = scores.std(axis=0)
 
-        for k in xrange(3):
+        for k in range_(3):
             ax = plt.subplot(2, 2, k + 1)
             plt.plot(thresholds, avg_scores[k, :], 'b')
             plt.plot(thresholds, avg_scores[k, :] + std_scores[k, :], 'k--')
@@ -332,7 +333,7 @@ def evaluate_models_tokens(datadir, dragnet_model, figname_root=None,
         # write a table
         if figname_root is not None:
             ftable.write("Threshold | Precision | Recall | F1\n")
-            for k in xrange(len(thresholds)):
+            for k in range_(len(thresholds)):
                 ftable.write("%s            %5.3f    %5.3f   %5.3f\n" % (thresholds[k], avg_scores[0, k], avg_scores[1, k], avg_scores[2, k]))
 
             i += 1

--- a/dragnet/models.py
+++ b/dragnet/models.py
@@ -1,4 +1,3 @@
-
 import pkgutil
 import cPickle as pickle
 import os
@@ -22,8 +21,8 @@ with GzipFile(
 
 with GzipFile(
     fileobj=StringIO(pkgutil.get_data(
-        'dragnet', 
-         os.path.join('pickled_models', 
+        'dragnet',
+         os.path.join('pickled_models',
             'kohlschuetter_weninger_readability_content_comments_model.pickle.gz'))),
     mode='r') as fin:
     content_comments_extractor = pickle.load(fin)
@@ -36,7 +35,7 @@ kohlschuetter_css_model = pickle.loads(
 kohlschuetter_css_weninger_model = pickle.loads(
     pkgutil.get_data('dragnet', 'pickled_models/kohlschuetter_css_weninger_100.0_content_model.pickle'))
 kohlschuetter_weninger_model = pickle.loads(
-        pkgutil.get_data('dragnet', 'pickled_models/kohlschuetter_weninger_1.0_content_model.pickle'))
+    pkgutil.get_data('dragnet', 'pickled_models/kohlschuetter_weninger_1.0_content_model.pickle'))
 
 
 # monkey patch the blockifiers to eliminate CSS features when not needed
@@ -54,4 +53,3 @@ content_and_content_comments_extractor = ContentCommentsExtractionModel(
     content_extractor._blockifier, content_extractor._features,
     content_extractor._block_model, content_comments_extractor._block_model,
     content_extractor._threshold)
-

--- a/dragnet/util.py
+++ b/dragnet/util.py
@@ -1,9 +1,15 @@
-# The Levenshtein distance code was originally taken from (retrieved June 21, 2012):
-#    http://mwh.geek.nz/2009/04/26/python-damerau-levenshtein-distance/
-#
-# It may eventually be updated to use different scores for insrtions, deletions,
-# transpositions, etc. For the time being, however, it remains as presented in
-# the article.
+"""
+The Levenshtein distance code was originally taken from (retrieved June 21, 2012):
+   http://mwh.geek.nz/2009/04/26/python-damerau-levenshtein-distance/
+
+It may eventually be updated to use different scores for insertions, deletions,
+transpositions, etc. For the time being, however, it remains as presented in
+the article.
+"""
+
+from .compat import range_
+
+
 def dameraulevenshtein(seq1, seq2):
     """Calculate the Damerau-Levenshtein distance between sequences.
 
@@ -33,12 +39,12 @@ def dameraulevenshtein(seq1, seq2):
     # so we only store those.
     oneago = None
     thisrow = range(1, len(seq2) + 1) + [0]
-    for x in xrange(len(seq1)):
+    for x in range_(len(seq1)):
         # Python lists wrap around for negative indices, so put the
         # leftmost column at the *end* of the list. This matches with
         # the zero-indexed strings and saves extra calculation.
         twoago, oneago, thisrow = oneago, thisrow, [0] * len(seq2) + [x + 1]
-        for y in xrange(len(seq2)):
+        for y in range_(len(seq2)):
             delcost = oneago[y] + 1
             addcost = thisrow[y - 1] + 1
             subcost = oneago[y - 1] + (seq1[x] != seq2[y])

--- a/dragnet/util.py
+++ b/dragnet/util.py
@@ -1,8 +1,3 @@
-
-
-import json
-import re
-
 # The Levenshtein distance code was originally taken from (retrieved June 21, 2012):
 #    http://mwh.geek.nz/2009/04/26/python-damerau-levenshtein-distance/
 #
@@ -49,11 +44,10 @@ def dameraulevenshtein(seq1, seq2):
             subcost = oneago[y - 1] + (seq1[x] != seq2[y])
             thisrow[y] = min(delcost, addcost, subcost)
             # This block deals with transpositions
-            if (x > 0 and y > 0 and seq1[x] == seq2[y - 1]
-                and seq1[x-1] == seq2[y] and seq1[x] != seq2[y]):
+            if (x > 0 and y > 0 and seq1[x] == seq2[y - 1] and
+                    seq1[x - 1] == seq2[y] and seq1[x] != seq2[y]):
                 thisrow[y] = min(thisrow[y], twoago[y - 2] + 1)
     return thisrow[len(seq2) - 1]
-
 
 
 def evaluation_metrics(predicted, actual, bow=True):
@@ -105,9 +99,5 @@ def evaluation_metrics(predicted, actual, bow=True):
     else:
         f1 = 2.0 * precision * recall / (precision + recall)
 
-    #return (precision, recall, f1, dameraulevenshtein(predicted, actual))
+    # return (precision, recall, f1, dameraulevenshtein(predicted, actual))
     return (precision, recall, f1)
-
-
-
-

--- a/dragnet/weninger.py
+++ b/dragnet/weninger.py
@@ -1,14 +1,17 @@
+"""
+inspired by
+Weninger, Tim, William H. Hsu, and Jiawei Han. "CETR: content extraction via
+    tag ratios." Proceedings of the 19th international conference on
+    World wide web. ACM, 2010.
+"""
+from __future__ import absolute_import
 
-# inspired by
-#Weninger, Tim, William H. Hsu, and Jiawei Han. "CETR: content extraction via
-#    tag ratios." Proceedings of the 19th international conference on
-#    World wide web. ACM, 2010.
 import numpy as np
+
 from .content_extraction_model import ContentExtractionModel
 from .blocks import TagCountBlockifier
 from .kmeans import KMeansFixedOrigin
-
-from _weninger import weninger_sx_sdx
+from ._weninger import weninger_sx_sdx
 
 
 def weninger_features(blocks, train=False):
@@ -22,6 +25,7 @@ def weninger_features(blocks, train=False):
     ctr = block_lengths / tagcounts
     sx_sdx = weninger_sx_sdx(ctr)
     return sx_sdx
+
 weninger_features.nfeatures = 2
 
 
@@ -47,7 +51,7 @@ weninger_features_kmeans.nfeatures = 1
 
 
 class Weninger(ContentExtractionModel):
+
     def __init__(self, clusters=3, blockifier=TagCountBlockifier, **kwargs):
         features = [weninger_features]
         ContentExtractionModel.__init__(self, blockifier, features, WeningerKMeanModel(clusters), **kwargs)
-

--- a/test/test_content_extraction_model.py
+++ b/test/test_content_extraction_model.py
@@ -1,16 +1,20 @@
-
 import unittest
-from dragnet import Blockifier, kohlschuetter, ContentExtractionModel, NormalizedFeature, kohlschuetter_features
 import re
 import numpy as np
 from mozsci.models import LogisticRegression
 from html_for_testing import big_html_doc
 
+from dragnet import (Blockifier, kohlschuetter, ContentExtractionModel,
+                     NormalizedFeature, kohlschuetter_features)
+
+
 class TestContentExtractionModel(unittest.TestCase):
+
     def test_dragnet_model(self):
-        params = {'b':0.2, 'w':[0.4, -0.2, 0.9, 0.8, -0.3, -0.5]}
+        params = {'b': 0.2, 'w': [0.4, -0.2, 0.9, 0.8, -0.3, -0.5]}
         block_model = LogisticRegression.load_model(params)
-        mean_std = {'mean':[0.0, 0.1, 0.2, 0.5, 0.0, 0.3], 'std':[1.0, 2.0, 0.5, 1.2, 0.75, 1.3]}
+        mean_std = {'mean': [0.0, 0.1, 0.2, 0.5, 0.0, 0.3],
+                    'std': [1.0, 2.0, 0.5, 1.2, 0.75, 1.3]}
         koh_features = NormalizedFeature(kohlschuetter_features, mean_std)
 
         dm = ContentExtractionModel(Blockifier, [koh_features], block_model, threshold=0.5)
@@ -21,7 +25,7 @@ class TestContentExtractionModel(unittest.TestCase):
         features, blocks = kohlschuetter.make_features(big_html_doc)
         nblocks = len(blocks)
         features_normalized = np.zeros(features.shape)
-        for k in xrange(6):
+        for k in range(6):
             features_normalized[:, k] = (features[:, k] - mean_std['mean'][k]) / mean_std['std'][k]
         blocks_keep_indices = np.arange(nblocks)[block_model.predict(features_normalized) > 0.5]
 
@@ -29,9 +33,8 @@ class TestContentExtractionModel(unittest.TestCase):
 
         # check that the tokens are the same!
         self.assertEqual(re.split('\s+', actual_content.strip()),
-                        re.split('\s+', content.strip()))
+                         re.split('\s+', content.strip()))
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/test/test_kohlschuetter.py
+++ b/test/test_kohlschuetter.py
@@ -1,20 +1,22 @@
-
 import unittest
-from dragnet import Blockifier, BlockifyError, kohlschuetter
 from lxml import etree
 import re
 import numpy as np
-from mozsci.models import LogisticRegression
 from html_for_testing import big_html_doc
 
+from dragnet import Blockifier, BlockifyError, kohlschuetter
+from dragnet.compat import range_
+
+
 class KohlschuetterUnitBase(unittest.TestCase):
+
     def block_output_tokens(self, blocks, true_tokens):
         """blocks = the output from blockify
            true_tokens = a list of true tokens"""
 
         self.assertTrue(len(blocks) == len(true_tokens))
 
-        for k in xrange(len(blocks)):
+        for k in range_(len(blocks)):
             block_tokens = re.split('\s+', blocks[k].text.strip())
             self.assertEqual(block_tokens, true_tokens[k])
 
@@ -22,12 +24,12 @@ class KohlschuetterUnitBase(unittest.TestCase):
         self.assertTrue(len(blocks) == len(true_tokens))
 
         link_tokens = [ele.link_tokens for ele in blocks]
-        for k in xrange(len(link_tokens)):
+        for k in range_(len(link_tokens)):
             self.assertEqual(link_tokens[k], true_tokens[k])
 
     def css_output_tokens(self, blocks, attrib, true_tokens):
         self.assertEqual(len(blocks), len(true_tokens))
-        for k in xrange(len(blocks)):
+        for k in range_(len(blocks)):
             css_tokens = re.split('\s+', blocks[k].css[attrib].strip())
             self.assertEqual(css_tokens, true_tokens[k])
 
@@ -42,7 +44,7 @@ class TestBlockifier(KohlschuetterUnitBase):
         self.assertRaises(BlockifyError, Blockifier.blockify, '')
 
         # this returns None in lxml
-        self.assertTrue(None == etree.fromstring('<!--', etree.HTMLParser(recover=True)) )
+        self.assertTrue(etree.fromstring('<!--', etree.HTMLParser(recover=True)) is None)
         self.assertRaises(BlockifyError, Blockifier.blockify, '<!--')
 
     def test_very_simple(self):
@@ -72,8 +74,8 @@ class TestBlockifier(KohlschuetterUnitBase):
                     <pre> <div>skip this</div> </pre>
                     <b>bold stuff</b> after the script
                </div>"""
-        blocks = Blockifier.blockify(s,
-            parse_callback=TestBlockifier.count_divs)
+        blocks = Blockifier.blockify(
+            s, parse_callback=TestBlockifier.count_divs)
         self.assertEqual(TestBlockifier.div_count, 2)
 
     def test_simple_two_blocks(self):
@@ -81,9 +83,11 @@ class TestBlockifier(KohlschuetterUnitBase):
                some text outside the h1
                <div>a div <span class="test"> with a span </span> more </div>"""
         blocks = Blockifier.blockify(s)
-        self.block_output_tokens(blocks,
-               [['A', 'title', 'with', 'italics', 'and', 'other', 'words', 'some', 'text', 'outside', 'the', 'h1'],
-                ['a', 'div', 'with', 'a', 'span', 'more']])
+        self.block_output_tokens(
+            blocks,
+            [['A', 'title', 'with', 'italics', 'and', 'other', 'words', 'some', 'text', 'outside', 'the', 'h1'],
+             ['a', 'div', 'with', 'a', 'span', 'more']]
+            )
 
     def test_comment(self):
         s = """<H1>h1 tag word</H1>
@@ -93,9 +97,11 @@ class TestBlockifier(KohlschuetterUnitBase):
                final
                """
         blocks = Blockifier.blockify(s)
-        self.block_output_tokens(blocks,
-                [['h1', 'tag', 'word', 'orphaned', 'text'],
-                 ['table', 'data', 'second', 'row', 'final']])
+        self.block_output_tokens(
+            blocks,
+            [['h1', 'tag', 'word', 'orphaned', 'text'],
+             ['table', 'data', 'second', 'row', 'final']]
+            )
 
     def test_empty_blocks(self):
         s = """<div> .! </div>
@@ -104,8 +110,8 @@ class TestBlockifier(KohlschuetterUnitBase):
                <p> ! _ </p>
             """
         blocks = Blockifier.blockify(s)
-        self.block_output_tokens(blocks,
-                    [['.!', 'some', 'text'], ['in', 'an', 'h1']])
+        self.block_output_tokens(
+            blocks, [['.!', 'some', 'text'], ['in', 'an', 'h1']])
 
     def test_nested_blocks(self):
         s = """initial text
@@ -116,14 +122,16 @@ class TestBlockifier(KohlschuetterUnitBase):
             final
             <div> <i> italic </i> before <h1>tag</h1></div>"""
         blocks = Blockifier.blockify(s)
-        self.block_output_tokens(blocks,
-                [['initial', 'text'],
-                ['div'],
-                ['with', 'paragraph', 'after', 'Paragraph'],
-                ['nested', 'div'],
-                ['and', 'again', 'here', 'final'],
-                ['italic', 'before'],
-                ['tag']])
+        self.block_output_tokens(
+            blocks,
+            [['initial', 'text'],
+             ['div'],
+             ['with', 'paragraph', 'after', 'Paragraph'],
+             ['nested', 'div'],
+             ['and', 'again', 'here', 'final'],
+             ['italic', 'before'],
+             ['tag']]
+            )
 
     def test_anchors(self):
         s = """<a href=".">anchor text</a>
@@ -132,40 +140,47 @@ class TestBlockifier(KohlschuetterUnitBase):
                an img link<a href="."><img src="."></a>there
                <table><tr><td><a href=".">WILL <img src="."> THIS PASS <b>THE TEST</b> ??</a></tr></td></table>"""
         blocks = Blockifier.blockify(s)
-
-        self.block_output_tokens(blocks,
-              [['anchor', 'text', 'more'],
-              ['text', '123'],
-              ['MORE!', 'an', 'img', 'link', 'there'],
-              ['WILL', 'THIS', 'PASS', 'THE', 'TEST', '??']])
-
-        self.link_output_tokens(blocks,
+        self.block_output_tokens(
+            blocks,
+            [['anchor', 'text', 'more'],
+             ['text', '123'],
+             ['MORE!', 'an', 'img', 'link', 'there'],
+             ['WILL', 'THIS', 'PASS', 'THE', 'TEST', '??']]
+            )
+        self.link_output_tokens(
+            blocks,
             [['anchor', 'text'],
              ['123'],
              [],
-             ['WILL', 'THIS', 'PASS', 'THE', 'TEST', '??']])
-
+             ['WILL', 'THIS', 'PASS', 'THE', 'TEST', '??']]
+            )
 
     def test_unicode(self):
         s = u"""<div><div><a href="."> the registered trademark \xae</a></div></div>"""
         blocks = Blockifier.blockify(s)
-        self.block_output_tokens(blocks,
+        self.block_output_tokens(
+            blocks,
             [['the', 'registered', 'trademark', u'\xae'.encode('utf-8')]])
-        self.link_output_tokens(blocks,
+        self.link_output_tokens(
+            blocks,
             [['the', 'registered', 'trademark', u'\xae'.encode('utf-8')]])
 
     def test_all_non_english(self):
         s = u"""<div> <div> \u03b4\u03bf\u03b3 </div> <div> <a href="summer">\xe9t\xe9</a> </div>
          <div> \u62a5\u9053\u4e00\u51fa </div> </div>"""
         blocks = Blockifier.blockify(s)
-        self.block_output_tokens(blocks,
+        self.block_output_tokens(
+            blocks,
             [[u'\u03b4\u03bf\u03b3'.encode('utf-8')],
-            [u'\xe9t\xe9'.encode('utf-8')],
-            [u'\u62a5\u9053\u4e00\u51fa'.encode('utf-8')]])
-        self.link_output_tokens(blocks,
+             [u'\xe9t\xe9'.encode('utf-8')],
+             [u'\u62a5\u9053\u4e00\u51fa'.encode('utf-8')]]
+            )
+        self.link_output_tokens(
+            blocks,
             [[],
              [u'\xe9t\xe9'.encode('utf-8')],
-             []])
+             []]
+            )
 
     def test_class_id(self):
         s = """<div CLASS='d1'>text in div
@@ -173,109 +188,95 @@ class TestBlockifier(KohlschuetterUnitBase):
                 <div class="nested">dragnet</div>
                 </div>"""
         blocks = Blockifier.blockify(s)
-
-        self.block_output_tokens(blocks,
-            [['text', 'in', 'div'],
-            ['header'],
-            ['dragnet']])
-
-        self.css_output_tokens(blocks, 'id',
-            [[''],
-             ['header'],
-             ['']])
-
-        self.css_output_tokens(blocks, 'class',
-            [['d1'],
-             [''],
-             ['nested']])
-
+        self.block_output_tokens(
+            blocks, [['text', 'in', 'div'], ['header'], ['dragnet']])
+        self.css_output_tokens(
+            blocks, 'id', [[''], ['header'], ['']])
+        self.css_output_tokens(
+            blocks, 'class', [['d1'], [''], ['nested']])
 
     def test_class_id_unicode(self):
         s = """<div CLASS=' class1 \xc2\xae'>text in div
                 <h1 id="HEADER">header</h1>
                 </div>"""
         blocks = Blockifier.blockify(s, encoding='utf-8')
-
-        self.block_output_tokens(blocks,
-            [['text', 'in', 'div'],
-            ['header']])
-
-        self.css_output_tokens(blocks, 'id',
-            [[''],
-             ['header']])
-
-        self.css_output_tokens(blocks, 'class',
-            [['class1', '\xc2\xae'],
-             ['']])
+        self.block_output_tokens(
+            blocks, [['text', 'in', 'div'], ['header']])
+        self.css_output_tokens(
+            blocks, 'id', [[''], ['header']])
+        self.css_output_tokens(
+            blocks, 'class', [['class1', '\xc2\xae'], ['']])
 
     def test_invalid_bytes(self):
-        # \x80 is invalid utf-8 
+        # \x80 is invalid utf-8
         s = """<div CLASS='\x80'>text in div</div><p>invalid bytes \x80</p>"""
         blocks = Blockifier.blockify(s, encoding='utf-8')
         self.block_output_tokens(blocks, [['text', 'in', 'div']])
         self.css_output_tokens(blocks, 'class', [['\xc2\x80']])
 
-
     def test_big_html(self):
         s = big_html_doc
         blocks = Blockifier.blockify(s)
-
-        self.block_output_tokens(blocks,
-        [['Inside', 'the', 'h1', 'tag'],
-        ['First', 'line', 'of', 'the', 'content', 'in', 'bold'],
-        ['A', 'paragraph', 'with', 'a', 'link', 'and', 'some', 'additional', 'words.'],
-        ['Second', 'paragraph', 'Insert', 'a', 'block', 'quote', 'here'],
-        ['Some', 'more', 'text', 'after', 'the', 'image'],
-        ['An', 'h2', 'tag', 'just', 'for', 'kicks'],
-        ['Finally', 'more', 'text', 'at', 'the', 'end', 'of', 'the', 'content'],
-        ['This', 'is', 'a', 'comment'],
-        ['with', 'two', 'paragraphs', 'and', 'some', 'comment', 'spam'],
-        ['Second', 'comment'],
-        ['Footer', 'text']])
-
-        self.link_output_tokens(blocks,
+        self.block_output_tokens(
+            blocks,
+            [['Inside', 'the', 'h1', 'tag'],
+             ['First', 'line', 'of', 'the', 'content', 'in', 'bold'],
+             ['A', 'paragraph', 'with', 'a', 'link', 'and', 'some', 'additional', 'words.'],
+             ['Second', 'paragraph', 'Insert', 'a', 'block', 'quote', 'here'],
+             ['Some', 'more', 'text', 'after', 'the', 'image'],
+             ['An', 'h2', 'tag', 'just', 'for', 'kicks'],
+             ['Finally', 'more', 'text', 'at', 'the', 'end', 'of', 'the', 'content'],
+             ['This', 'is', 'a', 'comment'],
+             ['with', 'two', 'paragraphs', 'and', 'some', 'comment', 'spam'],
+             ['Second', 'comment'],
+             ['Footer', 'text']]
+            )
+        self.link_output_tokens(
+            blocks,
             [[],
-            [],
-            ['a', 'link'],
-            [],
-            [],
-            [],
-            [],
-            [],
-            ['and', 'some', 'comment', 'spam'],
-            [],
-            []])
-
-        self.css_output_tokens(blocks, 'class',
+             [],
+             ['a', 'link'],
+             [],
+             [],
+             [],
+             [],
+             [],
+             ['and', 'some', 'comment', 'spam'],
+             [],
+             []]
+            )
+        self.css_output_tokens(
+            blocks, 'class',
             [[''],
-            ['title'],
-            ['link'],
-            [''],
-            [''],
-            [''],
-            [''],
-            [''],
-            [''],
-            [''],
-            ['footer']])
-
-
-        self.css_output_tokens(blocks, 'id',
+             ['title'],
+             ['link'],
+             [''],
+             [''],
+             [''],
+             [''],
+             [''],
+             [''],
+             [''],
+             ['footer']]
+            )
+        self.css_output_tokens(
+            blocks, 'id',
             [[''],
-            ['content'],
-            ['para'],
-            [''],
-            [''],
-            [''],
-            [''],
-            [''],
-            [''],
-            [''],
-            ['']])
-
+             ['content'],
+             ['para'],
+             [''],
+             [''],
+             [''],
+             [''],
+             [''],
+             [''],
+             [''],
+             ['']]
+            )
 
 
 class TestKohlschuetter(KohlschuetterUnitBase):
+
     def test_small_doc(self):
         self.assertEqual((None, []), kohlschuetter.make_features('<html></html>'))
         self.assertEqual('', kohlschuetter.analyze('<html></html>'))
@@ -285,7 +286,6 @@ class TestKohlschuetter(KohlschuetterUnitBase):
         self.assertTrue(features is None)
         self.block_output_tokens(blocks, [['a'], ['b']])
         self.assertEqual('a b', kohlschuetter.analyze(s))
-
 
     def test_make_features(self):
         s = '<html> <p>first </p> <div> <p>second block with <a href=''>anchor</a> </p> <p>the third block</p> </div> </html>'
@@ -301,8 +301,5 @@ class TestKohlschuetter(KohlschuetterUnitBase):
         self.assertTrue(np.allclose(features[2, :], [link_density[1], text_density[1], link_density[2], text_density[2], 0.0, 0.0]))
 
 
-
 if __name__ == "__main__":
     unittest.main()
-
-

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -2,18 +2,22 @@
 import unittest
 import json
 import os.path
-from dragnet.models import * 
+
+from dragnet.models import *
+from dragnet.compat import range_
 
 FIXTURES = 'test/datafiles'
 
+
 class TestModels(unittest.TestCase):
+
     def setUp(self):
         self._html = open(os.path.join(
             FIXTURES, 'models_testing.html'), 'r').read()
 
     def test_models(self):
         models = [kohlschuetter_model,
-                  weninger_model, 
+                  weninger_model,
                   kohlschuetter_weninger_model,
                   kohlschuetter_css_model,
                   kohlschuetter_css_weninger_model,
@@ -23,14 +27,14 @@ class TestModels(unittest.TestCase):
         actual_content = json.load(open(
             os.path.join(FIXTURES, 'models_content.json'), 'r'))
 
-        for k in xrange(len(models)):
+        for k in range_(len(models)):
             # some of the models (weninger) aren't deterministic
             # so the content doesn't match exactly every time,
             # although it passes most of the time
             # we allow a max of 5 failures before failing the entire test
             m = models[k]
             passed = False
-            for i in xrange(5):
+            for i in range_(5):
                 content = m.analyze(self._html)
                 if actual_content[k].encode('utf-8') == content:
                     passed = True
@@ -43,7 +47,7 @@ class TestModels(unittest.TestCase):
 
         passed_content = False
         passed_content_comments = False
-        for i in xrange(5):
+        for i in range_(5):
             actual_content, actual_content_comments = \
                 content_and_content_comments_extractor.analyze(self._html)
             passed_content = actual_content == content
@@ -65,18 +69,18 @@ class TestModels(unittest.TestCase):
 
         passed_content = False
         passed_content_comments = False
-        for i in xrange(5):
+        for i in range_(5):
             actual_content, actual_content_comments = \
                 content_and_content_comments_extractor.analyze(
                     self._html, blocks=True)
             passed_content = (
                 [blk.text for blk in actual_content] ==
                 [blk.text for blk in content]
-            )
+                )
             passed_content_comments = (
-                [blk.text for blk in actual_content_comments] == 
+                [blk.text for blk in actual_content_comments] ==
                 [blk.text for blk in content_comments]
-            )
+                )
             if passed_content and passed_content_comments:
                 break
 
@@ -85,5 +89,3 @@ class TestModels(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-
-


### PR DESCRIPTION
- Many minor changes in whitespace, indentation, imports, etc. to clean up the code à la pep8. No code behavior should change.
- Added a `compat.py` module with standardized Py2/3 compatible built-ins, and replaced the Py2-only equivalents in all modules:`xrange` => `compat.range_`, `unicode` => `compat.unicode_`, etc.
- Replaced all `print` statements with `print()` functions via `from __future__ import print_function`
- Replaced sets of string literals in `blocks.pyx` with explicit bytes, compatible with Py3 in addition to Py2

Unfortunately, _something_ has changed in the code's behavior, and 1 test out of 39 now fails. Specifically, the `kohlschuetter_css_model` model's extracted content fails to match the actual content in `test_models()`, even after 5 tries. I don't understand why this is.

One other note: `scipy.weave` is Py2 only, so its use in `arias.py` is incompatible with Py3. It looks like the recommendation is to use Cython directly, but I didn't want to muck around with that just yet.