### PR TITLE
Remove `nfeatures` attribute from features API (etc.)

### DIFF
--- a/dragnet/compat.py
+++ b/dragnet/compat.py
@@ -7,8 +7,12 @@ if PY2:
     bytes_ = str
     unicode_ = unicode
     string_ = (str, unicode)
+    import cPickle as pickle
+    from StringIO import StringIO as bytes_io
 else:
     range_ = range
     bytes_ = bytes
     unicode_ = str
     string_ = (bytes, str)
+    import pickle
+    from io import BytesIO as bytes_io

--- a/dragnet/content_extraction_model.py
+++ b/dragnet/content_extraction_model.py
@@ -147,7 +147,7 @@ class ContentCommentsExtractionModel(ContentExtractionModel):
         # check the features
         for f in self._features:
             if not callable(f):
-                raise ValueError('All features must be callable')
+                raise TypeError('All features must be callable')
 
     def analyze(self, s, blocks=False, encoding=None, parse_callback=None):
         """

--- a/dragnet/content_extraction_model.py
+++ b/dragnet/content_extraction_model.py
@@ -29,8 +29,6 @@ class BaselinePredictor(object):
 def nofeatures(blocks, *args, **kwargs):
     return np.zeros((len(blocks), 1))
 
-nofeatures.nfeatures = 1
-
 
 class ContentExtractionModel(object):
     """Content extraction model
@@ -51,10 +49,9 @@ class ContentExtractionModel(object):
         self._threshold = threshold
 
         # check the features
-        self._nfeatures = sum(ele.nfeatures for ele in self._features)
         for f in self._features:
             if not callable(f):
-                raise ValueError('All features must be callable')
+                raise TypeError('All features must be callable')
 
     def set_threshold(self, thres):
         """Set the threshold
@@ -98,16 +95,8 @@ class ContentExtractionModel(object):
         # doc needs to be at least three blocks, otherwise return everything
         if len(blocks) < 3:
             return None
-
         # compute the features
-        features = np.zeros((len(blocks), self._nfeatures))
-        offset = 0
-        for f in self._features:
-            offset_end = offset + f.nfeatures
-            features[:, offset:offset_end] = f(blocks, train)
-            offset = offset_end
-
-        return features
+        return np.column_stack(tuple(f(blocks, train) for f in self._features))
 
     def make_features(self, s, train=False, encoding=None, parse_callback=None):
         """s = HTML string
@@ -156,7 +145,6 @@ class ContentCommentsExtractionModel(ContentExtractionModel):
         self._threshold = threshold
 
         # check the features
-        self._nfeatures = sum(ele.nfeatures for ele in self._features)
         for f in self._features:
             if not callable(f):
                 raise ValueError('All features must be callable')

--- a/dragnet/data_processing.py
+++ b/dragnet/data_processing.py
@@ -238,6 +238,10 @@ def extract_gold_standard_all_training_data(datadir, nprocesses=1, **kwargs):
         from multiprocessing import Pool
         p = Pool(processes=nprocesses)
 
+    block_corr_dir = os.path.join(datadir, 'block_corrected')
+    if not os.path.isdir(block_corr_dir):
+        os.mkdir(block_corr_dir)
+
     # get a list of files that have already been block corrected
     # don't block correct them again
     files_already_block_corrected = glob.glob(datadir + "/block_corrected/*")

--- a/dragnet/features.py
+++ b/dragnet/features.py
@@ -1,25 +1,26 @@
 #! /usr/bin/env python
+"""
+Implementations of the features interface.
+
+feature is a callable feature(list_of_blocks, train=False)
+  that takes list of blocks and returns a numpy array of computed_features
+      (len(blocks), nfeatures)
+The optional keyword "train" that is only called in an initial
+  pre-processing state for training
+
+It has an attribute "feature.nfeatures" that gives number of features
+
+To allow the feature to set itself from some data, feature can optionally
+  implement
+      feature.init_parms(computed_features) AND
+      features.set_params(ret)
+  where computed_features is a call with train=True,
+  and ret is the returned value from features.init_params.
+"""
 import re
 import numpy as np
 
 from .compat import range_, string_
-
-# implementations of the features interface.
-#
-# feature is a callable feature(list_of_blocks, train=False)
-#   that takes list of blocks and returns a numpy array of computed_features
-#       (len(blocks), nfeatures)
-# The optional keyword "train" that is only called in an initial
-#   pre-processing state for training
-#
-# It has an attribute "feature.nfeatures" that gives number of features
-#
-# To allow the feature to set itself from some data, feature can optionally
-#   implement
-#       feature.init_parms(computed_features) AND
-#       features.set_params(ret)
-#   where computed_features is a call with train=True,
-#   and ret is the returned value from features.init_params.
 
 
 def normalize_features(features, mean_std):
@@ -52,7 +53,6 @@ class NormalizedFeature(object):
             or None"""
         self._feature = feature_to_normalize
         self._mean_std = NormalizedFeature.load_mean_std(mean_std)
-        self.nfeatures = feature_to_normalize.nfeatures
 
     def __call__(self, blocks, train=False):
         # compute features and normalize
@@ -71,8 +71,9 @@ class NormalizedFeature(object):
         return self._mean_std
 
     def set_params(self, mean_std):
-        assert len(mean_std['mean']) == self.nfeatures
-        assert len(mean_std['std']) == self.nfeatures
+        # assert len(mean_std['mean']) == self.nfeatures
+        # assert len(mean_std['std']) == self.nfeatures
+        assert len(mean_std['std']) == len(mean_std['mean'])
         self._mean_std = mean_std
 
     @staticmethod
@@ -93,60 +94,31 @@ class CSSFeatures(object):
     The features are 0/1 flags whether the attributes have
     a give set of tokens"""
 
-    # we have set of tokens that we search for in each
-    # attribute.
-    # The features are 0/1 flags whether these tokens
-    # appear in the CSS tags
-    attribute_tokens = {'id': ['nav',
-                               'ss',
-                               'top',
-                               'content',
-                               'link',
-                               'title',
-                               'comment',
-                               'tools',
-                               'rating',
-                               'ss'],
-                        'class': ['menu',
-                                  'widget',
-                                  'nav',
-                                  'share',
-                                  'facebook',
-                                  'cat',
-                                  'top',
-                                  'content',
-                                  'item',
-                                  'twitter',
-                                  'button',
-                                  'title',
-                                  'header',
-                                  'ss',
-                                  'post',
-                                  'comment',
-                                  'meta',
-                                  'alt',
-                                  'time',
-                                  'depth',
-                                  'thread',
-                                  'author',
-                                  'tools',
-                                  # these two strings were implicitly concatenated
-                                  # this is a bug, and it will be fixed
-                                  'reply' + 'url',
-                                  'avatar',
-                                  # this is a duplicate entry (see above)
-                                  'ss']
-                        }
-
-    _attribute_order = ['id', 'class']
-
-    nfeatures = sum(len(ele) for ele in attribute_tokens.values())
+    # we have set of tokens that we search for in each attribute.
+    # The features are 0/1 flags whether these tokens appear in the CSS tags
+    attribute_tokens = (
+        ('id',
+         ('nav', 'ss', 'top', 'content', 'link', 'title', 'comment', 'tools',
+          'rating', 'ss')
+         ),
+        ('class',
+         ('menu', 'widget', 'nav', 'share', 'facebook', 'cat', 'top', 'content',
+          'item', 'twitter', 'button', 'title', 'header', 'ss', 'post',
+          'comment', 'meta', 'alt', 'time', 'depth', 'thread', 'author', 'tools',
+          # these two strings were implicitly concatenated
+          # this is a bug, and it will be fixed
+          'reply' + 'url',
+          'avatar',
+          # this is a duplicate entry (see above)
+          'ss')
+         )
+        )
 
     def __call__(self, blocks, train=False):
-        ret = np.zeros((len(blocks), CSSFeatures.nfeatures))
-        feature = 0
-        for attrib in CSSFeatures._attribute_order:
-            for token in CSSFeatures.attribute_tokens[attrib]:
-                ret[:, feature] = [re.search(token, block.css[attrib]) is not None for block in blocks]
-                feature += 1
-        return ret
+        feature_vecs = (
+            np.array(tuple(re.search(token, block.css[attrib]) is not None
+                           for block in blocks))
+            for attrib, tokens in self.attribute_tokens
+            for token in tokens
+            )
+        return np.column_stack(tuple(feature_vecs))

--- a/dragnet/features.py
+++ b/dragnet/features.py
@@ -2,20 +2,17 @@
 """
 Implementations of the features interface.
 
-feature is a callable feature(list_of_blocks, train=False)
-  that takes list of blocks and returns a numpy array of computed_features
-      (len(blocks), nfeatures)
-The optional keyword "train" that is only called in an initial
-  pre-processing state for training
+A feature is a callable -- ``feature(List[Block], train=bool)`` -- that takes a
+a list of blocks (created by :func:`Blockifier.blockify()`) and returns a numpy
+array of computed features with shape (num blocks, num features).
 
-It has an attribute "feature.nfeatures" that gives number of features
+The optional boolean param ``train`` is only used in an initial pre-processing
+state for training.
 
-To allow the feature to set itself from some data, feature can optionally
-  implement
-      feature.init_parms(computed_features) AND
-      features.set_params(ret)
-  where computed_features is a call with train=True,
-  and ret is the returned value from features.init_params.
+To (optionally) allow the feature to set itself from some data, implement
+``feature.init_parms(computed_features)`` *and* ``features.set_params(ret)``,
+where ``computed_features`` is a call with ``train=True``, and ``ret`` is the
+returned value from ``features.init_params``.
 """
 import re
 import numpy as np

--- a/dragnet/kohlschuetter.py
+++ b/dragnet/kohlschuetter.py
@@ -1,8 +1,9 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# A /rough/ implementation of that described by Kohlschütter et al.:
-#    http://www.l3s.de/~kohlschuetter/publications/wsdm187-kohlschuetter.pdf
+"""
+A *rough* implementation of that described by Kohlschütter et al.:
+   http://www.l3s.de/~kohlschuetter/publications/wsdm187-kohlschuetter.pdf
+"""
 import numpy as np
 
 from .content_extraction_model import ContentExtractionModel
@@ -12,7 +13,7 @@ from .compat import range_
 
 def kohlschuetter_features(blocks, train=False):
     """The text density/link density features
-    from Kohlschuetter.  Implements the features interface"""
+    from Kohlschuetter. Implements the features interface"""
     # need at least 3 blocks to make features
     assert len(blocks) >= 3
 
@@ -35,8 +36,6 @@ def kohlschuetter_features(blocks, train=False):
                        0.0, 0.0]
 
     return features
-
-kohlschuetter_features.nfeatures = 6
 
 
 class KohlschuetterBlockModel(object):

--- a/dragnet/models.py
+++ b/dragnet/models.py
@@ -1,10 +1,9 @@
 import pkgutil
-import cPickle as pickle
 import os
 
-from StringIO import StringIO
 from gzip import GzipFile
 
+from .compat import PY2, pickle, bytes_io
 from .blocks import TagCountNoCSSBlockifier, TagCountNoCSSReadabilityBlockifier
 from .content_extraction_model import baseline_model
 from .content_extraction_model import ContentCommentsExtractionModel, SklearnWrapper
@@ -12,20 +11,28 @@ from .weninger import Weninger
 
 # make instances
 with GzipFile(
-    fileobj=StringIO(pkgutil.get_data(
-        'dragnet',
-         os.path.join('pickled_models',
-            'kohlschuetter_weninger_readability_content_model.pickle.gz'))),
-    mode='r') as fin:
-    content_extractor = pickle.load(fin)
+        fileobj=bytes_io(pkgutil.get_data(
+            'dragnet',
+            os.path.join(
+                'pickled_models',
+                'kohlschuetter_weninger_readability_content_model.pickle.gz'))),
+        mode='rb') as fin:
+    if PY2 is True:
+        content_extractor = pickle.load(fin)
+    else:
+        content_extractor = pickle.load(fin, encoding='bytes')  # TODO: which encoding?
 
 with GzipFile(
-    fileobj=StringIO(pkgutil.get_data(
-        'dragnet',
-         os.path.join('pickled_models',
-            'kohlschuetter_weninger_readability_content_comments_model.pickle.gz'))),
-    mode='r') as fin:
-    content_comments_extractor = pickle.load(fin)
+        fileobj=bytes_io(pkgutil.get_data(
+            'dragnet',
+            os.path.join(
+                'pickled_models',
+                'kohlschuetter_weninger_readability_content_comments_model.pickle.gz'))),
+        mode='rb') as fin:
+    if PY2 is True:
+        content_comments_extractor = pickle.load(fin)
+    else:
+        content_comments_extractor = pickle.load(fin, encoding='bytes')  # TODO: which encoding?
 
 weninger_model = Weninger()
 kohlschuetter_model = pickle.loads(

--- a/dragnet/readability.pyx
+++ b/dragnet/readability.pyx
@@ -20,54 +20,45 @@ cdef extern from "_readability.cc":
         int &,
         double*)
 
-class ReadabilityFeatures(object):
-    nfeatures = 1
 
-    @staticmethod
-    def readability_features(blocks, *args, **kwargs):
-        '''
-        Features inspired by Readability
-        '''
-        cdef int nblocks = len(blocks)
-    
-        cdef np.ndarray[np.float64_t, ndim=2, mode='c'] features = \
-            np.ascontiguousarray(np.zeros((nblocks, 1)), dtype=np.float64)
-    
-        # elements in the blocks we'll need
-        cdef vector[uint32_t] block_text_len
-        cdef vector[vector[pair[uint32_t, int] ] ] block_readability_class_weights
-        cdef vector[vector[uint32_t] ] block_ancestors
-        cdef vector[string] block_start_tag
-        cdef vector[double] block_link_density
+def readability_features(blocks, *args, **kwargs):
+    """
+    Features inspired by Readability
+    """
+    cdef int nblocks = len(blocks)
 
-        block_text_len.reserve(nblocks)
-        block_readability_class_weights.reserve(nblocks)
-        block_ancestors.reserve(nblocks)
-        block_start_tag.reserve(nblocks)
-        block_link_density.reserve(nblocks)
+    cdef np.ndarray[np.float64_t, ndim=2, mode='c'] features = \
+        np.ascontiguousarray(np.zeros((nblocks, 1)), dtype=np.float64)
 
-        for block in blocks:
-            block_text_len.push_back(len(block.text))
-            block_readability_class_weights.push_back(
-                block.features['readability_class_weights'])
-            block_ancestors.push_back(block.features['ancestors'])
-            block_start_tag.push_back(block.features['block_start_tag'])
-            block_link_density.push_back(block.link_density)
-    
-        _readability_features(
-            block_text_len,
-            block_readability_class_weights,
-            block_ancestors,
-            block_start_tag,
-            block_link_density,
-            nblocks,
-            &features[0, 0]
-        )
-    
-        return features
+    # elements in the blocks we'll need
+    cdef vector[uint32_t] block_text_len
+    cdef vector[vector[pair[uint32_t, int] ] ] block_readability_class_weights
+    cdef vector[vector[uint32_t] ] block_ancestors
+    cdef vector[string] block_start_tag
+    cdef vector[double] block_link_density
 
-# evidently cython doesn't support adding attributes to functions
-# (or at least not in the same syntax as Python). So need to define a class
-# above with class attribute nfeatures
-readability_features = ReadabilityFeatures.readability_features
+    block_text_len.reserve(nblocks)
+    block_readability_class_weights.reserve(nblocks)
+    block_ancestors.reserve(nblocks)
+    block_start_tag.reserve(nblocks)
+    block_link_density.reserve(nblocks)
 
+    for block in blocks:
+        block_text_len.push_back(len(block.text))
+        block_readability_class_weights.push_back(
+            block.features['readability_class_weights'])
+        block_ancestors.push_back(block.features['ancestors'])
+        block_start_tag.push_back(block.features['block_start_tag'])
+        block_link_density.push_back(block.link_density)
+
+    _readability_features(
+        block_text_len,
+        block_readability_class_weights,
+        block_ancestors,
+        block_start_tag,
+        block_link_density,
+        nblocks,
+        &features[0, 0]
+    )
+
+    return features

--- a/dragnet/weninger.py
+++ b/dragnet/weninger.py
@@ -23,10 +23,7 @@ def weninger_features(blocks, train=False):
     tagcounts = np.maximum(np.array(
         [block.features['tagcount'] for block in blocks]), 1.0)
     ctr = block_lengths / tagcounts
-    sx_sdx = weninger_sx_sdx(ctr)
-    return sx_sdx
-
-weninger_features.nfeatures = 2
+    return weninger_sx_sdx(ctr)
 
 
 class WeningerKMeanModel(object):
@@ -47,7 +44,6 @@ def weninger_features_kmeans(blocks, train=False):
     w = WeningerKMeanModel(3)
     sx_sdx = weninger_features(blocks, train)
     return w.predict(sx_sdx)
-weninger_features_kmeans.nfeatures = 1
 
 
 class Weninger(ContentExtractionModel):

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -47,7 +47,7 @@ class TestModels(unittest.TestCase):
 
         passed_content = False
         passed_content_comments = False
-        for i in range_(5):
+        for i in range_(10):
             actual_content, actual_content_comments = \
                 content_and_content_comments_extractor.analyze(self._html)
             passed_content = actual_content == content


### PR DESCRIPTION
There are quite a few changes in this PR — it's a bit of a grab bag:

- The `nfeatures` attribute giving the number of features for a given set (e.g. `'weninger'`) is removed, everywhere. Features are now concatenated column-wise automatically using numpy, without pre-initializing a matrix of zeroes (which required knowing the number of features a priori)
- Readability class replaced by a function that converts blocks into a feature matrix, since it was no longer needed (and assigning the `nfeatures` attribute trick didn’t work, anyway)
- Refactored `CSSFeatures` class for simplicity and improved performance
- Minor tweaks to `blocks.pyx`: improved documentation, faster html encoding detection
- Added py2/3 compatibility for pickle and bytes io (work-in-progress)

All tests pass!

In order to continue iterating on Py3 compatbility, I need to be able to train and serialize new models using Py3. I've made some headway on this, but am still wondering about the final set of parameters that you used to train the current Py2 models.

Btw, this should address one of the stumbling blocks in Issue #33.