### PR TITLE
Set the working directory to /vagrant by default on login.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 
 Dragnet
-=====================================
+=======
 
 [![Build Status](https://api.travis-ci.org/seomoz/dragnet.png)](https://api.travis-ci.org/seomoz/dragnet.png)
 
-Dragnet isn't interested in the shiny chrome or boilerplate dressing of a 
-web page. It's interested in... 'just the facts.'  The machine learning
-models in Dragnet extract the main article content and optionally
-user generated comments from a web page.  They provide state
-of the art performance on variety of test benchmarks.
+Dragnet isn't interested in the shiny chrome or boilerplate dressing
+of a web page. It's interested in... 'just the facts.'  The machine
+learning models in Dragnet extract the main article content and
+optionally user generated comments from a web page.  They provide
+state of the art performance on variety of test benchmarks.
 
 For more information on our approach check out:
 
@@ -17,8 +17,8 @@ at WWW in 2013, gives an overview of the machine learning approach.
 * [A comparison](https://moz.com/devblog/benchmarking-python-content-extraction-algorithms-dragnet-readability-goose-and-eatiht/) of Dragnet and alternate content extraction packages.
 * [This blog post](https://moz.com/devblog/dragnet-content-extraction-from-diverse-feature-sets/) explains the intuition behind the algorithms.
 
-This project was originally inspired by 
-Kohlschütter et al, [Boilerplate Detection using Shallow Text Features](http://www.l3s.de/~kohlschuetter/publications/wsdm187-kohlschuetter.pdf) and 
+This project was originally inspired by
+Kohlschütter et al, [Boilerplate Detection using Shallow Text Features](http://www.l3s.de/~kohlschuetter/publications/wsdm187-kohlschuetter.pdf) and
 Weninger et al [CETR -- Content Extraction with Tag Ratios](http://web.engr.illinois.edu/~weninge1/cetr/), and more recently by [Readability](https://github.com/buriy/python-readability).
 
 # GETTING STARTED
@@ -79,8 +79,6 @@ virtual machine with Dragnet and it's dependencies.
 
 ```bash
 vagrant ssh
-# inside the vagrant vm
-$ cd /vagrant
 # these should now pass
 $ make test
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,14 +5,15 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
+  config.vm.hostname = 'dragnet'
 
-    # lxml has trouble building if the amount of memory is 512:
-    # http://stackoverflow.com/questions/16149613/installing-lxml-with-pip-in-virtualenv-ubuntu-12-10-error-command-gcc-failed
+  # lxml has trouble building if the amount of memory is 512:
+  # http://stackoverflow.com/questions/16149613/installing-lxml-with-pip-in-virtualenv-ubuntu-12-10-error-command-gcc-failed
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "2048"
   end
 
-   config.vm.provision "shell", privileged: false, inline: <<-SHELL
-     cd /vagrant; ./provision.sh
-   SHELL
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    cd /vagrant; ./provision.sh
+  SHELL
 end

--- a/provision.sh
+++ b/provision.sh
@@ -18,6 +18,8 @@ export PATH=$HOME/py/bin:$PATH
 # configure conda for future login (for vagrant)
 echo "export PATH=$PATH" >> $HOME/.bashrc
 
+echo "cd /vagrant" >> $HOME/.bashrc
+
 pip install "Cython>=0.21.1"
 pip install -r requirements.txt
 


### PR DESCRIPTION
This makes it so that you can run `make test` immediately without having to manually run `cd /vagrant/`.