### PR TITLE
Bump sklearn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ nose
 coverage
 Cython>=0.21.1
 lxml
-scikit-learn>=0.15.2,<=0.19.0
+scikit-learn>=0.15.2,<=0.19.2
 numpy
 scipy
 ftfy>=4.1.0,<5.0.0

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     install_requires = [
         'Cython>=0.21.1',
         'lxml',
-        'scikit-learn>=0.15.2,<0.19.0',
+        'scikit-learn>=0.15.2,<=0.19.2',
         'numpy',
         'scipy',
         'ftfy>=4.1.0,<5.0.0'


### PR DESCRIPTION
Locking the sklearn version to under 0.19.0 limits compatibility with many other 3rd party libraries if used within a larger project.  There doesn't appear to be any breaking changes for dragnet when used with higher versions, so this PR bumps the required version to under 0.19.2.